### PR TITLE
feat: add TakerTraitsIsMakingAmount to UnpackLO1inchResult for enhanc…

### DIFF
--- a/pkg/oneinch/encode/lo1inch.go
+++ b/pkg/oneinch/encode/lo1inch.go
@@ -211,6 +211,7 @@ func PackLO1inch(_ valueobject.ChainID, encodingSwap EncodingSwap) ([][]byte, *b
 type UnpackLO1inchResult struct {
 	FillOrderArgs              *FillOrderArgs
 	FillContractOrderArgs      *FillContractOrderArgs
+	TakerTraitsIsMakingAmount  bool
 	AmountThreshold            *big.Int
 	Receiver                   *common.Address
 	Extension                  *limitorder.Extension
@@ -269,6 +270,8 @@ func UnpackLO1inch(decoded []byte) (*UnpackLO1inchResult, error) {
 			Extension:                  extension,
 			InteractionTarget:          &interaction.Target,
 			InteractionMinMakingAmount: minMakingAmount,
+			// expect to be false as VT is the taker side
+			TakerTraitsIsMakingAmount: takerTraits.IsMakingAmount(),
 		}, nil
 
 	case MethodFillContractOrderArgs:
@@ -308,6 +311,8 @@ func UnpackLO1inch(decoded []byte) (*UnpackLO1inchResult, error) {
 			Extension:                  extension,
 			InteractionTarget:          &interaction.Target,
 			InteractionMinMakingAmount: minMakingAmount,
+			// expect to be false as VT is the taker side
+			TakerTraitsIsMakingAmount: takerTraits.IsMakingAmount(),
 		}, nil
 
 	default:


### PR DESCRIPTION
…ed unpacking details

- Introduced TakerTraitsIsMakingAmount field to UnpackLO1inchResult struct to capture whether the taker is making the amount.
- Updated UnpackLO1inch function to populate the new field based on taker traits, improving the detail of unpacked results.