### PR TITLE
feat: extend FlashbotMevShareTxHint with full mev-share tx fields

### DIFF
--- a/pkg/types/flashbot_mevshare.go
+++ b/pkg/types/flashbot_mevshare.go
@@ -16,19 +16,19 @@ type SimulatedPrivateMempoolLog struct {
 }
 
 type FlashbotMevShareTxHint struct {
-	Hash                 *common.Hash         `json:"hash,omitempty"`
-	To                   *common.Address      `json:"to,omitempty"`
-	FunctionSelector     *hexutil.Bytes       `json:"functionSelector,omitempty"`
-	CallData             *hexutil.Bytes       `json:"callData,omitempty"`
-	From                 *common.Address      `json:"from,omitempty"`
-	Value                *hexutil.Big         `json:"value,omitempty"`
-	MaxFeePerGas         *hexutil.Big         `json:"maxFeePerGas,omitempty"`
-	MaxPriorityFeePerGas *hexutil.Big         `json:"maxPriorityFeePerGas,omitempty"`
-	Nonce                *hexutil.Uint64      `json:"nonce,omitempty"`
-	ChainID              *hexutil.Big         `json:"chainId,omitempty"`
+	Hash                 *common.Hash          `json:"hash,omitempty"`
+	To                   *common.Address       `json:"to,omitempty"`
+	FunctionSelector     *hexutil.Bytes        `json:"functionSelector,omitempty"`
+	CallData             *hexutil.Bytes        `json:"callData,omitempty"`
+	From                 *common.Address       `json:"from,omitempty"`
+	Value                *hexutil.Big          `json:"value,omitempty"`
+	MaxFeePerGas         *hexutil.Big          `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *hexutil.Big          `json:"maxPriorityFeePerGas,omitempty"`
+	Nonce                *hexutil.Uint64       `json:"nonce,omitempty"`
+	ChainID              *hexutil.Big          `json:"chainId,omitempty"`
 	AccessList           *gethtypes.AccessList `json:"accessList,omitempty"`
-	Gas                  *hexutil.Uint64      `json:"gas,omitempty"`
-	Type                 *hexutil.Uint64      `json:"type,omitempty"`
+	Gas                  *hexutil.Uint64       `json:"gas,omitempty"`
+	Type                 *hexutil.Uint64       `json:"type,omitempty"`
 }
 
 type FlashbotMevshareEvent struct {

--- a/pkg/types/flashbot_mevshare.go
+++ b/pkg/types/flashbot_mevshare.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 type SimulatedPrivateMempoolLog struct {
@@ -15,10 +16,19 @@ type SimulatedPrivateMempoolLog struct {
 }
 
 type FlashbotMevShareTxHint struct {
-	Hash             *common.Hash    `json:"hash,omitempty"`
-	To               *common.Address `json:"to,omitempty"`
-	FunctionSelector *hexutil.Bytes  `json:"functionSelector,omitempty"`
-	CallData         *hexutil.Bytes  `json:"callData,omitempty"`
+	Hash                 *common.Hash         `json:"hash,omitempty"`
+	To                   *common.Address      `json:"to,omitempty"`
+	FunctionSelector     *hexutil.Bytes       `json:"functionSelector,omitempty"`
+	CallData             *hexutil.Bytes       `json:"callData,omitempty"`
+	From                 *common.Address      `json:"from,omitempty"`
+	Value                *hexutil.Big         `json:"value,omitempty"`
+	MaxFeePerGas         *hexutil.Big         `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *hexutil.Big         `json:"maxPriorityFeePerGas,omitempty"`
+	Nonce                *hexutil.Uint64      `json:"nonce,omitempty"`
+	ChainID              *hexutil.Big         `json:"chainId,omitempty"`
+	AccessList           *gethtypes.AccessList `json:"accessList,omitempty"`
+	Gas                  *hexutil.Uint64      `json:"gas,omitempty"`
+	Type                 *hexutil.Uint64      `json:"type,omitempty"`
 }
 
 type FlashbotMevshareEvent struct {


### PR DESCRIPTION
## Summary
- Extend `FlashbotMevShareTxHint` to include the additional fields the mev-share SSE feed now emits when the bundle sender configures the `full` hint (TEE-searcher mode): `from`, `value`, `maxFeePerGas`, `maxPriorityFeePerGas`, `nonce`, `chainId`, `accessList`, `gas`, `type`.
- All new fields are optional pointers with `omitempty`, so consumers that ignore them keep working.
- `AccessList` uses `go-ethereum/core/types.AccessList` to match the on-the-wire shape `{address, storageKeys[]}`.

## Test plan
- [x] `go build ./...` passes locally.
- [ ] Downstream consumer (mempool-explorer) confirms parsing of a real mev-share full-hint event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)