### PR TITLE
refactor(mev): drop pre-submit simulation in BloxrouteBackrunmeSender.SendBackrunBundle

### DIFF
--- a/pkg/mev/bloxroute_backrunme_sender.go
+++ b/pkg/mev/bloxroute_backrunme_sender.go
@@ -157,13 +157,6 @@ func (s *BloxrouteBackrunmeSender) SendBackrunBundle(
 		transactions = append(transactions, hexTx)
 	}
 
-	// First, simulate the bundle using MevSimulateBundle
-	_, err := s.MevSimulateBundle(ctx, blockNumber, pendingTxHashes[0], txs[0])
-	if err != nil {
-		return SendBundleResponse{}, fmt.Errorf("simulate bundle failed: %w", err)
-	}
-
-	// If simulation passed, proceed with submission
 	// Build request params
 	params := backrunmeRequestParams{
 		TransactionHash: pendingTxHashes[0].Hex(),


### PR DESCRIPTION
## What

`BloxrouteBackrunmeSender.SendBackrunBundle` called `MevSimulateBundle` (`simulate_arb_only_bundle`) before submitting, and aborted the send if it errored. This drops that pre-submit simulation — `SendBackrunBundle` now goes straight to `submit_arb_only_bundle` (with `coinbase_profit`).

```diff
-	// First, simulate the bundle using MevSimulateBundle
-	_, err := s.MevSimulateBundle(ctx, blockNumber, pendingTxHashes[0], txs[0])
-	if err != nil {
-		return SendBundleResponse{}, fmt.Errorf("simulate bundle failed: %w", err)
-	}
-
-	// If simulation passed, proceed with submission
	// Build request params
	params := backrunmeRequestParams{ ... }
```

## Why

The pre-submit simulate round-trip is unnecessary on the send path and adds latency. `MevSimulateBundle` stays on the type (still part of `IBackrunSender`) for callers that want to simulate explicitly — only the implicit call inside `SendBackrunBundle` is removed.

Also resolves the earlier review note that `coinbase_profit` was carried by submit but not by the in-send simulate: there is no in-send simulate anymore, so the two can't diverge.

Build + vet clean; no signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)