### PR TITLE
feat(types): add ReserveTaker mempool source

### DIFF
--- a/pkg/types/pendingtx.go
+++ b/pkg/types/pendingtx.go
@@ -20,6 +20,7 @@ const (
 	BlinkV3Mempool
 	BloxRoute
 	InternalSolver
+	ReserveTaker
 )
 
 type Message struct {
@@ -142,7 +143,8 @@ func (m Message) GetAllLogs() []*types.Log {
 			}
 			return results
 		}
-	case MevBlockerMempool, PublicMempool, BlinkMempool, MerkleMempool, BlinkV3Mempool, BloxRoute, InternalSolver:
+	case MevBlockerMempool, PublicMempool, BlinkMempool, MerkleMempool, BlinkV3Mempool, BloxRoute,
+		InternalSolver, ReserveTaker:
 		logs := m.GetLogsFromSimulatedLog()
 		if m.InternalTx != nil {
 			return append(logs, m.InternalTx.getLogs()...)


### PR DESCRIPTION
## What
Add `ReserveTaker` to the `MempoolSource` enum (value 9) and include it in `Message.GetAllLogs`.

## Why
dexdex-arb is being extended to backrun arb bundles that **reserve-taker (vtv2)** is about to broadcast (via poseidon → mempool-explorer → redis bundle stream). Those bundles need a distinct source label:
- vtv2's own tx (always last in the bundle) is tagged `ReserveTaker` — the marker dexdex uses to detect a vtv2 bundle.
- For a vtv2 **normal** arb the merged bundle Message carries `Source == ReserveTaker`; `GetAllLogs` must return its `InternalTx` logs, so `ReserveTaker` is added alongside `InternalSolver` in the source switch (otherwise it falls through to `default: nil` and the pending pool state gets no logs).

## Downstream
mempool-explorer / poseidon / dexdex-arb will vendor this by commit hash until a `v0.11.19` tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)